### PR TITLE
Allow to use slices with WithObjects / WithReferences methods

### DIFF
--- a/v4/test/batch/batchCreate_test.go
+++ b/v4/test/batch/batchCreate_test.go
@@ -51,15 +51,22 @@ func TestBatchCreate_integration(t *testing.T) {
 				"description": "Putting the game of letter soups to a whole new level.",
 			},
 		}
+		classASlice := []*models.Object{classA1,classA2}
 
 		batchResultT, batchErrT := client.Batch().ObjectsBatcher().WithObject(classT1).WithObject(classT2).Do(context.Background())
 		assert.Nil(t, batchErrT)
 		assert.NotNil(t, batchResultT)
 		assert.Equal(t, 2, len(batchResultT))
-		batchResultA, batchErrA := client.Batch().ObjectsBatcher().WithObject(classA1).WithObject(classA2).Do(context.Background())
+		batchResultA, batchErrA := client.Batch().ObjectsBatcher().WithObjects(classA1,classA2).Do(context.Background())
 		assert.Nil(t, batchErrA)
 		assert.NotNil(t, batchResultA)
 		assert.Equal(t, 2, len(batchResultA))
+
+		batchResultSlice, batchErrSlice := client.Batch().ObjectsBatcher().WithObjects(classASlice...).Do(context.Background())
+		assert.Nil(t, batchErrSlice)
+		assert.NotNil(t, batchResultSlice)
+		assert.Equal(t, 2, len(batchResultSlice))
+
 
 		objectT1, objErrT1 := client.Data().ObjectsGetter().WithClassName("Pizza").WithID("abefd256-8574-442b-9293-9205193737ee").Do(context.Background())
 		assert.Nil(t, objErrT1)
@@ -124,7 +131,7 @@ func TestBatchCreate_integration(t *testing.T) {
 
 		// Add references in batch
 		referenceBatchResult, err := client.Batch().ReferencesBatcher().
-			WithReference(refTtoA).WithReference(refTtoT).WithReference(refAtoT).WithReference(refAtoA).Do(context.Background())
+			WithReference(refTtoA).WithReference(refTtoT).WithReferences(refAtoT, refAtoA).Do(context.Background())
 		assert.Nil(t, err)
 		assert.NotNil(t, referenceBatchResult)
 

--- a/v4/weaviate/batch/objectsCreate.go
+++ b/v4/weaviate/batch/objectsCreate.go
@@ -21,10 +21,17 @@ type ObjectsBatcher struct {
 	objects    []*models.Object
 }
 
-// WithObject add an object to the batch
-func (ob *ObjectsBatcher) WithObject(object *models.Object) *ObjectsBatcher {
-	ob.objects = append(ob.objects, object)
+// WithObjects adds objects to the batch
+func (ob *ObjectsBatcher) WithObjects(object... *models.Object) *ObjectsBatcher {
+	ob.objects = append(ob.objects, object...)
 	return ob
+}
+
+// WithObject adds one object to the batch
+//
+// Deprecated: Use WithObjects with the same syntax
+func (ob *ObjectsBatcher) WithObject(object *models.Object) *ObjectsBatcher {
+	return ob.WithObjects(object)
 }
 
 func (ob *ObjectsBatcher) resetObjects() {

--- a/v4/weaviate/batch/reference.go
+++ b/v4/weaviate/batch/reference.go
@@ -15,10 +15,17 @@ type ReferencesBatcher struct {
 	references []*models.BatchReference
 }
 
-// WithReference adds a reference to the current batch
-func (rb *ReferencesBatcher) WithReference(reference *models.BatchReference) *ReferencesBatcher {
-	rb.references = append(rb.references, reference)
+// WithReferences adds references to the current batch
+func (rb *ReferencesBatcher) WithReferences(reference ...*models.BatchReference) *ReferencesBatcher {
+	rb.references = append(rb.references, reference...)
 	return rb
+}
+
+// WithReference adds a reference to the current batch
+//
+// Deprecated: Use WithReferences with the same syntax
+func (rb *ReferencesBatcher) WithReference(reference *models.BatchReference) *ReferencesBatcher {
+	return rb.WithReferences(reference)
 }
 
 // Do add all the references in the batch to weaviate


### PR DESCRIPTION
When adding many objects/references, they can now be added in a single call without
looping over and appending each element separately.

Example:

Before:
```
	batcher := client.Batch().ObjectsBatcher()
	for _, obj := range objects {
		batcher.WithObject(obj)
	}
	_, err := batcher.Do(context.Background())
```

Now:

```
	res, err := client.Batch().ObjectsBatcher().WithObject(objects...).Do(context.Background())
```

----

Open questions/tasks:

- [ ]  Change code examples to use slices (https://github.com/semi-technologies/weaviate-io/blob/main/developers/weaviate/current/restful-api-references/objects.md)
- [x]  Is it worth adding a benchmark for adding objects/references to this repo alongside the normal tests? - Not doing this, we will focus on benchmarking weaviate directly and not the client.


----
Benchmark

I build a local benchmarked with a similar problem and using slices reduces the amount of memory allocations and speeds up creating a batch of 100.000 elements by a factor of ~10 on my (slooow) machine. Adding baches via a loop should be unaffected.

Explantion:

- AddSlice adds N elements via a slice
- AddLoop loops over N elements adding each with it's own WithObject call
- AddLoopSingle loops over N elements adding each with it's own WithObject call, using the old version (eg. without Variadic function parameter)

```
goos: linux
goarch: amd64
cpu: Intel(R) Core(TM) i5-4200U CPU @ 1.60GHz
BenchmarkSliceVsLoop/AddSlice/1-4         	11377264	       111.6 ns/op	      32 B/op	       2 allocs/op
BenchmarkSliceVsLoop/AddSlice/10-4        	 5242863	       216.4 ns/op	     104 B/op	       2 allocs/op
BenchmarkSliceVsLoop/AddSlice/100-4       	 1476933	       793.7 ns/op	     920 B/op	       2 allocs/op
BenchmarkSliceVsLoop/AddSlice/1000-4      	  187771	      6759 ns/op	    8216 B/op	       2 allocs/op
BenchmarkSliceVsLoop/AddSlice/10000-4     	   18159	     66061 ns/op	   81944 B/op	       2 allocs/op
BenchmarkSliceVsLoop/AddSlice/100000-4    	    1527	    757042 ns/op	  802840 B/op	       2 allocs/op
BenchmarkSliceVsLoop/AddLoop/1-4          	11975394	       106.6 ns/op	      32 B/op	       2 allocs/op
BenchmarkSliceVsLoop/AddLoop/10-4         	 1468382	      1077 ns/op	     272 B/op	       6 allocs/op
BenchmarkSliceVsLoop/AddLoop/100-4        	  255630	      4464 ns/op	    2064 B/op	       9 allocs/op
BenchmarkSliceVsLoop/AddLoop/1000-4       	   35242	     35246 ns/op	   25232 B/op	      13 allocs/op
BenchmarkSliceVsLoop/AddLoop/10000-4      	    4900	    473830 ns/op	  357648 B/op	      20 allocs/op
BenchmarkSliceVsLoop/AddLoop/100000-4     	     200	   5596702 ns/op	 4101392 B/op	      29 allocs/op
BenchmarkSliceVsLoop/AddLoopSingle/1-4    	10541823	       120.4 ns/op	      32 B/op	       2 allocs/op
BenchmarkSliceVsLoop/AddLoopSingle/10-4   	 1630070	       871.3 ns/op	     272 B/op	       6 allocs/op
BenchmarkSliceVsLoop/AddLoopSingle/100-4  	  445629	      3779 ns/op	    2064 B/op	       9 allocs/op
BenchmarkSliceVsLoop/AddLoopSingle/1000-4 	   36920	     30624 ns/op	   25232 B/op	      13 allocs/op
BenchmarkSliceVsLoop/AddLoopSingle/10000-4         	    6734	    400910 ns/op	  357648 B/op	      20 allocs/op
BenchmarkSliceVsLoop/AddLoopSingle/100000-4        	     163	   7495126 ns/op	 4101392 B/op	      29 allocs/op
PASS
```