### PR TITLE
Backup test fix for compatibility with DBRO

### DIFF
--- a/v4/test/backup/backup_test.go
+++ b/v4/test/backup/backup_test.go
@@ -460,12 +460,24 @@ func TestBackups_integration(t *testing.T) {
 				WithIncludeClassNames(className).
 				WithBackend(backend).
 				WithBackupID(backupID).
+				WithWaitForCompletion(true).
 				Do(context.Background())
 
-			require.NotNil(t, err)
-			require.Nil(t, restoreResponse)
-			assert.Contains(t, err.Error(), "422")
-			assert.Contains(t, err.Error(), className)
+			require.Nil(t, err)
+			require.NotNil(t, restoreResponse)
+			require.NotNil(t, restoreResponse.Status)
+			require.Equal(t, models.BackupRestoreResponseStatusFAILED, *restoreResponse.Status)
+
+			restoreStatusResponse, err := client.Backup().RestoreStatusGetter().
+				WithBackend(backend).
+				WithBackupID(backupID).
+				Do(context.Background())
+
+			require.Nil(t, err)
+			require.NotNil(t, restoreStatusResponse)
+			assert.Contains(t, restoreStatusResponse.Error, "restore class Pizza: already exists")
+			assert.Contains(t, restoreStatusResponse.ID, backupID)
+			assert.Contains(t, restoreStatusResponse.Error, className)
 		})
 	})
 
@@ -574,7 +586,6 @@ func TestBackups_integration(t *testing.T) {
 			require.NotNil(t, err)
 			require.Nil(t, restoreStatusResponse)
 			assert.Contains(t, err.Error(), "404")
-			assert.Contains(t, err.Error(), backend)
 			assert.Contains(t, err.Error(), backupID)
 		})
 	})

--- a/v4/test/backup/backup_test.go
+++ b/v4/test/backup/backup_test.go
@@ -465,19 +465,9 @@ func TestBackups_integration(t *testing.T) {
 
 			require.Nil(t, err)
 			require.NotNil(t, restoreResponse)
-			require.NotNil(t, restoreResponse.Status)
-			require.Equal(t, models.BackupRestoreResponseStatusFAILED, *restoreResponse.Status)
-
-			restoreStatusResponse, err := client.Backup().RestoreStatusGetter().
-				WithBackend(backend).
-				WithBackupID(backupID).
-				Do(context.Background())
-
-			require.Nil(t, err)
-			require.NotNil(t, restoreStatusResponse)
-			assert.Contains(t, restoreStatusResponse.Error, "restore class Pizza: already exists")
-			assert.Contains(t, restoreStatusResponse.ID, backupID)
-			assert.Contains(t, restoreStatusResponse.Error, className)
+			assert.Equal(t, models.BackupRestoreResponseStatusFAILED, *restoreResponse.Status)
+			assert.Contains(t, restoreResponse.Error, className)
+			assert.Contains(t, restoreResponse.Error, "already exists")
 		})
 	})
 

--- a/v4/test/docker-compose.yaml
+++ b/v4/test/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     - '8080'
     - --scheme
     - http
-    image: semitechnologies/weaviate:1.15.2
+    image: semitechnologies/weaviate:latest@sha256:6b4d510d59f57bd00d6b1cb5957db2bc80963e59355cd4dc8935c7c6f2df4559
     ports:
     - 8080:8080
     restart: on-failure:0
@@ -22,6 +22,8 @@ services:
       DEFAULT_VECTORIZER_MODULE: text2vec-contextionary
       ENABLE_MODULES: text2vec-contextionary,backup-filesystem
       BACKUP_FILESYSTEM_PATH: "/tmp/backups"
+      CLUSTER_GOSSIP_BIND_PORT: "7100" 
+      CLUSTER_DATA_BIND_PORT: "7101" 
   contextionary:
     image: semitechnologies/contextionary:en0.16.0-v1.1.0
     ports:


### PR DESCRIPTION
The backend changes were made in the new weaviate image that has been added to the docker-compose.yml. There were 2 small changes that needed to be made to the existing backup tests:

1. you now have to check restore status to determine if restore failed due to class already existing on node
2. a slight change to the error message when a restore status is not found